### PR TITLE
Use wg for goroutines instead of tasks

### DIFF
--- a/html_processing.go
+++ b/html_processing.go
@@ -15,6 +15,7 @@ import (
 // output directory.
 func processHTMLFile(htmlTasks <-chan Dir, wg *sync.WaitGroup, done <-chan struct{}) {
 	slog.Debug("Starting processHTML goroutine")
+	defer wg.Done()
 
 	tpl, err := template.ParseGlob("templates/default/*.go.html")
 	if err != nil {
@@ -26,7 +27,6 @@ func processHTMLFile(htmlTasks <-chan Dir, wg *sync.WaitGroup, done <-chan struc
 	for {
 		select {
 		case htmlTask := <-htmlTasks:
-			defer wg.Done()
 			slog.Debug("Received HTML task", "htmlTask", htmlTask)
 
 			navigation := []NavigationElement{}

--- a/html_processing_test.go
+++ b/html_processing_test.go
@@ -49,6 +49,7 @@ func TestProcessHTMLFile(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Start the processHTMLFile function in a goroutine
+	wg.Add(1)
 	go processHTMLFile(htmlTasks, &wg, done)
 
 	// Create a mock HTML task
@@ -64,7 +65,6 @@ func TestProcessHTMLFile(t *testing.T) {
 	}
 
 	// Send the task to the channel
-	wg.Add(1)
 	htmlTasks <- htmlTask
 	t.Log("Sent HTML task to channel:", htmlTask)
 
@@ -132,6 +132,7 @@ func TestProcessHTMLFileWithNewestFirst(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Start the processHTMLFile function in a goroutine
+	wg.Add(1)
 	go processHTMLFile(htmlTasks, &wg, done)
 
 	// Create a mock HTML task
@@ -154,7 +155,6 @@ func TestProcessHTMLFileWithNewestFirst(t *testing.T) {
 
 	t.Log("Sending HTML task to channel:", htmlTask)
 	// Send the task to the channel
-	wg.Add(1)
 	htmlTasks <- htmlTask
 
 	close(done)

--- a/image_processing.go
+++ b/image_processing.go
@@ -15,11 +15,11 @@ import (
 // It will resize the image, and copy it to the output directory.
 func processImage(imageTasks <-chan string, wg *sync.WaitGroup, done <-chan struct{}) {
 	slog.Debug("Starting processImage goroutine")
+	defer wg.Done()
 	var file string
 	for {
 		select {
 		case file = <-imageTasks:
-			defer wg.Done()
 			if file == "" {
 				slog.Debug("Received empty file path, skipping")
 				continue

--- a/process.go
+++ b/process.go
@@ -35,12 +35,14 @@ func process() error {
 	// Start the image processing goroutines
 	for range numRoutines {
 		slog.Debug("Starting image processing goroutines", "numRoutines", numRoutines)
+		wg.Add(1)
 		go processImage(imageTasks, wg, done)
 	}
 
 	// Start the HTML processing goroutines
 	for range numRoutines {
 		slog.Debug("Starting HTML processing goroutines", "numRoutines", numRoutines)
+		wg.Add(1)
 		go processHTMLFile(htmlTasks, wg, done)
 	}
 
@@ -117,7 +119,6 @@ func process() error {
 					}
 				}
 				if needsUpdate {
-					wg.Add(1)
 					imageTasks <- path
 				}
 				slog.Debug("Adding file to directory index", "path", path, "name", name)
@@ -141,7 +142,6 @@ func process() error {
 			slog.Debug("Processing directory", "dir", dir)
 			if len(dir.Files) > 0 || len(dir.SubDirs) > 0 {
 				slog.Debug("Adding directory to HTML tasks", "dir", dir)
-				wg.Add(1)
 				htmlTasks <- dir
 			}
 		}


### PR DESCRIPTION
This PR changes the WaitGroup to be used per goroutine instead of per task.