### PR TITLE
Fix RSS image inclusion

### DIFF
--- a/image_processing.go
+++ b/image_processing.go
@@ -97,18 +97,15 @@ func processImage(imageTasks <-chan string, RSSTasks chan<- RSSItem, wg *sync.Wa
 				slog.Error("Failed to get thumbnail file info", "error", err)
 				os.Exit(1)
 			}
-			URL := filepath.Join(config.GalleryURL, config.GalleryPath, strings.TrimPrefix(outputDir, config.Output))
+			baseURL := config.GalleryURL + filepath.Join(config.GalleryPath, strings.TrimPrefix(outputDir, config.Output))
+			imageURL := baseURL + "/#" + imgName
+			thumbURL := baseURL + "/thumb_" + imgName
 			RSSTasks <- RSSItem{
 				Title:       imgName,
-				Description: "Thumbnail for " + imgName,
-				Link:        filepath.Join(URL, "thumb_"+imgName),
+				Description: "%lt;img src=\"" + thumbURL + "\" alt=\"" + imgName + "\" /&gt;",
+				Link:        imageURL,
 				PubDate:     thumbFileInfo.ModTime().Format(time.RFC1123Z),
-				GUID:        filepath.Join(URL, "#"+imgName),
-				Enclosure: RSSItemEnclosure{
-					URL:    filepath.Join(URL, "#"+imgName),
-					Length: thumbFileInfo.Size(),
-					Type:   "image/jpeg",
-				},
+				GUID:        imageURL,
 			}
 
 		case <-done:

--- a/process.go
+++ b/process.go
@@ -72,7 +72,6 @@ func process() error {
 		}
 		modTime := fileInfo.ModTime()
 
-		thumbSize := int64(0)
 		thumbModTime := time.Time{}
 
 		parentDir := filepath.Dir(path)
@@ -131,7 +130,6 @@ func process() error {
 						} else {
 							slog.Debug("Output file is newer", "originalFile", path, "outputFile", outputFile)
 							if size == "thumb" {
-								thumbSize = outputFileInfo.Size()
 								thumbModTime = outputFileInfo.ModTime()
 							}
 						}
@@ -142,18 +140,15 @@ func process() error {
 				} else {
 					// Add the file to the RSS feed if it exists and we know the thumbnail size
 					// If the thumbnail size is 0, processImage will add it to the RSS feed instead
-					URL := filepath.Join(config.GalleryURL, config.GalleryPath, strings.TrimPrefix(outputDir, config.Output))
+					baseURL := config.GalleryURL + filepath.Join(config.GalleryPath, strings.TrimPrefix(outputDir, config.Output))
+					imageURL := baseURL + "/#" + name
+					thumbURL := baseURL + "/thumb_" + name
 					rssTasks <- RSSItem{
 						Title:       name,
-						Description: "Thumbnail for " + name,
-						Link:        filepath.Join(URL, "thumb_"+name),
+						Description: "&lt;img src=\"" + thumbURL + "\" alt=\"" + name + "\" /&gt;",
+						Link:        imageURL,
 						PubDate:     thumbModTime.Format(time.RFC1123Z),
-						GUID:        filepath.Join(URL, "#"+name),
-						Enclosure: RSSItemEnclosure{
-							URL:    filepath.Join(URL, "#"+name),
-							Length: thumbSize,
-							Type:   "image/jpeg",
-						},
+						GUID:        imageURL,
 					}
 				}
 				slog.Debug("Adding file to directory index", "path", path, "name", name)

--- a/templates/default/rss.go.xml
+++ b/templates/default/rss.go.xml
@@ -13,7 +13,7 @@
         <item>
             <title>{{.Title}}</title>
             <link>{{.Link}}</link>
-            <description><![CDATA[{{.Description}}]]></description>
+            <description>{{.Description}}</description>
             <pubDate>{{.PubDate}}</pubDate>
             <guid>{{.GUID}}</guid>
         </item>

--- a/types.go
+++ b/types.go
@@ -15,19 +15,12 @@ type Folders struct {
 	Folders []string
 }
 
-type RSSItemEnclosure struct {
-	URL    string
-	Type   string
-	Length int64
-}
-
 type RSSItem struct {
 	Title       string
 	Description string
 	Link        string
 	PubDate     string
 	GUID        string
-	Enclosure   RSSItemEnclosure
 }
 
 type RSSFeed struct {


### PR DESCRIPTION
This PR fixes the RSS image inclusion.

Not all readers included the image directly when using the `enclosure` tag, whereas they seem to load an included `img` in the `description` tag.